### PR TITLE
Server/Database: Drop Support for older MySQL libs then 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Discord link: https://discord.gg/y3zspxan7k
 + Platform: Linux, Windows or Mac
 + Processor with SSE2 support
 + ACE = 7.0.0 (included for Windows) 
-+ MySQL = 5.7
++ MySQL = 8.0 (Windows / Linux)
 + CMake ≥ 3.14 (latest stable recommended) 
 + OpenSSL = 1.x.x
 + Boost ≥ 1.70 (latest stable recommended)
 + Windows SDK version 10
 + MS Visual Studio (Community) ≥ 16.4 (2019) (Desktop) (Not previews) 
++ MS Visual Studio (Community) ≥ 17.1 (2022) (Desktop) (With installed MSVC v142 - VS 2019 - Single Component Setup) (Not previews) 
 + GCC = 4.7.2 (Linux only)
 
 ## Copyright

--- a/cmake/macros/FindMySQL.cmake
+++ b/cmake/macros/FindMySQL.cmake
@@ -10,23 +10,23 @@
 # also defined, but not for general use are
 # MYSQL_LIBRARY, where to find the MySQL library.
 
-set( MYSQL_FOUND 0 )
+set(MYSQL_FOUND 0)
 
 if(WIN32)
   # read environment variables and change \ to /
   SET(PROGRAM_FILES_32 $ENV{ProgramFiles})
-  if (${PROGRAM_FILES_32})
+  if(${PROGRAM_FILES_32})
     STRING(REPLACE "\\\\" "/" PROGRAM_FILES_32 ${PROGRAM_FILES_32})
   endif(${PROGRAM_FILES_32})
 
   SET(PROGRAM_FILES_64 $ENV{ProgramW6432})
-  if (${PROGRAM_FILES_64})
+  if(${PROGRAM_FILES_64})
      STRING(REPLACE "\\\\" "/" PROGRAM_FILES_64 ${PROGRAM_FILES_64})
   endif(${PROGRAM_FILES_64})
 endif(WIN32)
 
 # Find MariaDB for Windows
-if (WIN32)
+if(WIN32)
   # Set know versions MariaDB
   set(_MARIADB_KNOWN_VERSIONS "MariaDB 10.5" "MariaDB 10.4" "MariaDB 10.3" "MariaDB 10.2")
 
@@ -85,20 +85,20 @@ if (WIN32)
     DOC
         "path to your mysql binary.")
 
-  if (MYSQL_LIBRARY AND MYSQL_INCLUDE_DIR AND MYSQL_EXECUTABLE)
+  if(MYSQL_LIBRARY AND MYSQL_INCLUDE_DIR AND MYSQL_EXECUTABLE)
     set(MARIADB_FOUND 1)
   endif()
 
   endmacro(FindLibMariaDB)
 
   foreach(version ${_MARIADB_KNOWN_VERSIONS})
-    if (NOT MARIADB_FOUND)
+    if(NOT MARIADB_FOUND)
       FindLibMariaDB(${version})
     endif()
   endforeach()
 endif()
 
-if( UNIX )
+if(UNIX)
   set(MYSQL_CONFIG_PREFER_PATH "$ENV{MYSQL_HOME}/bin" CACHE FILEPATH
     "preferred path to MySQL (mysql_config)"
   )
@@ -110,7 +110,7 @@ if( UNIX )
     /usr/bin/
   )
 
-  if( MYSQL_CONFIG )
+  if(MYSQL_CONFIG)
     message(STATUS "Using mysql-config: ${MYSQL_CONFIG}")
     # set INCLUDE_DIR
     exec_program(${MYSQL_CONFIG}
@@ -142,11 +142,11 @@ if( UNIX )
       #message("[DEBUG] MYSQL ADD_LIBRARIES_PATH : ${MYSQL_ADD_LIBRARIES_PATH}")
     endforeach(LIB ${MYSQL_LIBS})
 
-  else( MYSQL_CONFIG )
+  else(MYSQL_CONFIG)
     set(MYSQL_ADD_LIBRARIES "")
     list(APPEND MYSQL_ADD_LIBRARIES "mysqlclient_r")
-  endif( MYSQL_CONFIG )
-endif( UNIX )
+  endif(MYSQL_CONFIG)
+endif(UNIX)
 
 find_path(MYSQL_INCLUDE_DIR
   NAMES
@@ -159,16 +159,10 @@ find_path(MYSQL_INCLUDE_DIR
     /usr/local/include/mysql
     /usr/local/mysql/include
     "C:/Program Files/MySQL/MySQL Server 8.0/include"
-    "C:/Program Files/MySQL/MySQL Server 5.7/include"
-    "C:/Program Files/MySQL/MySQL Server 5.6/include"
     "C:/Program Files/MySQL/include"
     "C:/MySQL/include"
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 8.0;Location]/include"
-    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 5.7;Location]/include"
-    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 5.6;Location]/include"
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.0;Location]/include"
-    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 5.7;Location]/include"
-    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 5.6;Location]/include"
     "$ENV{ProgramFiles}/MySQL/*/include"
     "$ENV{SystemDrive}/MySQL/*/include"
     "c:/msys/local/include"
@@ -177,9 +171,9 @@ find_path(MYSQL_INCLUDE_DIR
     "Specify the directory containing mysql.h."
 )
 
-if( UNIX )
+if(UNIX)
   foreach(LIB ${MYSQL_ADD_LIBRARIES})
-    find_library( MYSQL_LIBRARY
+    find_library(MYSQL_LIBRARY
       NAMES
         mysql libmysql ${LIB}
       PATHS
@@ -189,60 +183,47 @@ if( UNIX )
         /usr/local/lib
         /usr/local/lib/mysql
         /usr/local/mysql/lib
-      DOC "Specify the location of the mysql library here."
-    )
+      DOC "Specify the location of the mysql library here.")
   endforeach(LIB ${MYSQL_ADD_LIBRARY})
-endif( UNIX )
+endif(UNIX)
 
-if( WIN32 )
-  find_library( MYSQL_LIBRARY
+if(WIN32)
+  find_library(MYSQL_LIBRARY
     NAMES
       libmysql
     PATHS
       ${MYSQL_ADD_LIBRARIES_PATH}
       "C:/Program Files/MySQL/MySQL Server 8.0/lib"
       "C:/Program Files/MySQL/MySQL Server 8.0/lib/opt"
-      "C:/Program Files/MySQL/MySQL Server 5.7/lib/opt"
-      "C:/Program Files/MySQL/MySQL Server 5.6/lib/opt"
       "C:/Program Files/MySQL/lib"
       "C:/MySQL/lib/debug"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 8.0;Location]/lib"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 8.0;Location]/lib/opt"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 5.7;Location]/lib"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 5.7;Location]/lib/opt"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 5.6;Location]/lib"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 5.6;Location]/lib/opt"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.0;Location]/lib"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.0;Location]/lib/opt"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 5.7;Location]/lib"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 5.7;Location]/lib/opt"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 5.6;Location]/lib"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 5.6;Location]/lib/opt"
       "$ENV{ProgramFiles}/MySQL/*/lib/opt"
       "$ENV{SystemDrive}/MySQL/*/lib/opt"
       "c:/msys/local/include"
       "$ENV{MYSQL_LIBRARY}"
-    DOC "Specify the location of the mysql library here."
-  )
-endif( WIN32 )
+    DOC "Specify the location of the mysql library here.")
+endif(WIN32)
 
 # On Windows you typically don't need to include any extra libraries
 # to build MYSQL stuff.
-if( NOT WIN32 )
-  find_library( MYSQL_EXTRA_LIBRARIES
+if(NOT WIN32)
+  find_library(MYSQL_EXTRA_LIBRARIES
     NAMES
       z zlib
     PATHS
       /usr/lib
       /usr/local/lib
     DOC
-      "if more libraries are necessary to link in a MySQL client (typically zlib), specify them here."
-  )
-else( NOT WIN32 )
-  set( MYSQL_EXTRA_LIBRARIES "" )
-endif( NOT WIN32 )
+      "if more libraries are necessary to link in a MySQL client (typically zlib), specify them here.")
+else(NOT WIN32)
+  set(MYSQL_EXTRA_LIBRARIES "")
+endif(NOT WIN32)
 
-if( UNIX )
+if(UNIX)
   find_program(MYSQL_EXECUTABLE mysql
     PATHS
       ${MYSQL_CONFIG_PREFER_PATH}
@@ -250,54 +231,43 @@ if( UNIX )
       /usr/local/bin/
       /usr/bin/
     DOC
-      "path to your mysql binary."
-  )
-endif( UNIX )
+      "path to your mysql binary.")
+endif(UNIX)
 
-if( WIN32 )
+if(WIN32)
   find_program(MYSQL_EXECUTABLE mysql
     PATHS
       "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.0/bin"
-      "${PROGRAM_FILES_64}/MySQL/MySQL Server 5.7/bin"
       "${PROGRAM_FILES_64}/MySQL/MySQL Server 8.0/bin/opt"
-      "${PROGRAM_FILES_64}/MySQL/MySQL Server 5.7/bin/opt"
       "${PROGRAM_FILES_64}/MySQL/bin"
       "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.0/bin"
-      "${PROGRAM_FILES_32}/MySQL/MySQL Server 5.7/bin"
       "${PROGRAM_FILES_32}/MySQL/MySQL Server 8.0/bin/opt"
-      "${PROGRAM_FILES_32}/MySQL/MySQL Server 5.7/bin/opt"
       "${PROGRAM_FILES_32}/MySQL/bin"
       "C:/MySQL/bin/debug"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 8.0;Location]/bin"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 5.7;Location]/bin"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 8.0;Location]/bin/opt"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MySQL AB\\MySQL Server 5.7;Location]/bin/opt"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.0;Location]/bin"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 5.7;Location]/bin"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 8.0;Location]/bin/opt"
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\MySQL AB\\MySQL Server 5.7;Location]/bin/opt"
       "$ENV{ProgramFiles}/MySQL/MySQL Server 8.0/bin/opt"
-      "$ENV{ProgramFiles}/MySQL/MySQL Server 5.7/bin/opt"
       "$ENV{SystemDrive}/MySQL/MySQL Server 8.0/bin/opt"
-      "$ENV{SystemDrive}/MySQL/MySQL Server 5.7/bin/opt"
       "c:/msys/local/include"
       "$ENV{MYSQL_ROOT}/bin"
     DOC
       "path to your mysql binary.")
-endif( WIN32 )
+endif(WIN32)
 
-if( MYSQL_LIBRARY )
-  if( MYSQL_INCLUDE_DIR )
-    set( MYSQL_FOUND 1 )
+if(MYSQL_LIBRARY)
+  if(MYSQL_INCLUDE_DIR)
+    set(MYSQL_FOUND 1)
     message(STATUS "Found MySQL library: ${MYSQL_LIBRARY}")
     message(STATUS "Found MySQL headers: ${MYSQL_INCLUDE_DIR}")
-  else( MYSQL_INCLUDE_DIR )
+  else(MYSQL_INCLUDE_DIR)
     message(FATAL_ERROR "Could not find MySQL headers! Please install the development libraries and headers")
-  endif( MYSQL_INCLUDE_DIR )
-  if( MYSQL_EXECUTABLE )
+  endif(MYSQL_INCLUDE_DIR)
+  if(MYSQL_EXECUTABLE)
     message(STATUS "Found MySQL executable: ${MYSQL_EXECUTABLE}")
-  endif( MYSQL_EXECUTABLE )
-  mark_as_advanced( MYSQL_FOUND MYSQL_LIBRARY MYSQL_EXTRA_LIBRARIES MYSQL_INCLUDE_DIR MYSQL_EXECUTABLE )
-else( MYSQL_LIBRARY )
+  endif(MYSQL_EXECUTABLE)
+  mark_as_advanced(MYSQL_FOUND MYSQL_LIBRARY MYSQL_EXTRA_LIBRARIES MYSQL_INCLUDE_DIR MYSQL_EXECUTABLE)
+else(MYSQL_LIBRARY)
   message(FATAL_ERROR "Could not find the MySQL libraries! Please install the development libraries and headers")
-endif( MYSQL_LIBRARY )
+endif(MYSQL_LIBRARY)

--- a/src/server/shared/Database/PreparedStatement.cpp
+++ b/src/server/shared/Database/PreparedStatement.cpp
@@ -210,7 +210,7 @@ m_bind(NULL)
     memset(m_bind, 0, sizeof(MYSQL_BIND)*m_paramCount);
 
     /// "If set to 1, causes mysql_stmt_store_result() to update the metadata MYSQL_FIELD->max_length value."
-    my_bool bool_tmp = 1;
+    bool bool_tmp = 1;
     mysql_stmt_attr_set(stmt, STMT_ATTR_UPDATE_MAX_LENGTH, &bool_tmp);
 }
 

--- a/src/server/shared/Database/QueryResult.cpp
+++ b/src/server/shared/Database/QueryResult.cpp
@@ -48,10 +48,10 @@ m_length(NULL)
     }
 
     m_rBind = new MYSQL_BIND[m_fieldCount];
-    m_isNull = new my_bool[m_fieldCount];
+    m_isNull = new bool[m_fieldCount];
     m_length = new unsigned long[m_fieldCount];
 
-    memset(m_isNull, 0, sizeof(my_bool) * m_fieldCount);
+    memset(m_isNull, 0, sizeof(bool) * m_fieldCount);
     memset(m_rBind, 0, sizeof(MYSQL_BIND) * m_fieldCount);
     memset(m_length, 0, sizeof(unsigned long) * m_fieldCount);
 

--- a/src/server/shared/Database/QueryResult.h
+++ b/src/server/shared/Database/QueryResult.h
@@ -91,7 +91,7 @@ class PreparedResultSet
         MYSQL_STMT* m_stmt;
         MYSQL_RES* m_res;
 
-        my_bool* m_isNull;
+        bool* m_isNull;
         unsigned long* m_length;
 
         void FreeBindBuffer();


### PR DESCRIPTION
 Server/Database: Drop Support for older MySQL libs then 8.0, updated requirements in Readme, and fixed compile in MSVC.