### PR TITLE
Core: Now when adding a new in-game spawn of a creature or gob, the ScriptName (if any) will be loaded.

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1040,6 +1040,7 @@ void Creature::SaveToDB(uint32 mapid, uint16 spawnMask, uint32 phaseMask)
     data.unit_flags2 = unit_flags2;
     data.dynamicflags = dynamicflags;
     data.WalkMode = m_WalkMode;
+    data.ScriptId = !data.ScriptId && cinfo->ScriptID ? cinfo->ScriptID : data.ScriptId; // Don't add to stmt to save in DB 
 
     // update in DB
     SQLTransaction trans = WorldDatabase.BeginTransaction();

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -281,7 +281,7 @@ struct CreatureData
     uint32 unit_flags;                                      // enum UnitFlags mask values
     uint32 unit_flags2;                                     // enum UnitFlags2 mask values
     uint32 dynamicflags;
-    uint32 ScriptId;
+    uint32 ScriptId{};
     float WalkMode;
     bool dbData;
     uint32 gameEventId = 0;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -826,6 +826,7 @@ void GameObject::SaveToDB(uint32 mapid, uint16 spawnMask, uint32 phaseMask)
     data.go_state = GetGoState();
     data.spawnMask = spawnMask;
     data.artKit = GetGoArtKit();
+    data.ScriptId = !data.ScriptId && goI->ScriptId ? goI->ScriptId : data.ScriptId; // Don't add to stmt to save in DB 
 
     // Update in DB
     SQLTransaction trans = WorldDatabase.BeginTransaction();

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -785,7 +785,7 @@ struct GameObjectData
     GOState go_state;
     uint16 spawnMask;
     uint8 artKit;
-    uint32 ScriptId;
+    uint32 ScriptId{};
     bool dbData;
     uint32 gameEventId = 0;
 };


### PR DESCRIPTION
Note: This fixes the problem that made it necessary to restart the worldserver to load the scripts when adding a new spawn.

How to reproduce:
1. Just .npc add or .gob add to one that has ScriptName in db.
2. Check that the script was not loaded.