### PR TITLE
fix(core/compile): Compile on debian/ubuntu

### DIFF
--- a/src/server/shared/Cryptography/SHA1.cpp
+++ b/src/server/shared/Cryptography/SHA1.cpp
@@ -18,6 +18,7 @@
 #include "SHA1.h"
 #include "BigNumber.h"
 #include <stdarg.h>
+#include <cstring>
 
 SHA1Hash::SHA1Hash()
 {


### PR DESCRIPTION
Boost requires cstring (memcpy)