### PR TITLE
fix(grids): drop custom visibility objects when the grid unloads

### DIFF
--- a/src/server/game/Grids/ObjectGridLoader.cpp
+++ b/src/server/game/Grids/ObjectGridLoader.cpp
@@ -223,6 +223,17 @@ void ObjectGridUnloader::Visit(GridRefManager<T> &m)
         //Example: Flame Leviathan Turret 33139 is summoned when a creature is deleted
         /// @todo Check if that script has the correct logic. Do we really need to summons something before deleting?
         obj->CleanupsBeforeDelete();
+
+        // The loader registers objects with custom visibility on the map, and this
+        // is the one path that destroys them without going through
+        // Map::RemoveFromMap, so nothing else takes them back out. Left behind, the
+        // freed pointer stays in the set until the next visibility scan walks it -
+        // which is a crash inside Player::UpdateVisibilityForPlayer on the next
+        // login, reading fields off an object that no longer exists.
+        if (obj->HasCustomVisibility())
+            if (Map* map = obj->FindMap())
+                map->RemoveCustomVisibilityObject(obj, obj->GetCustomVisibilityZoneID());
+
         ///- object will get delinked from the manager when deleted
         delete obj;
     }


### PR DESCRIPTION
This pull request addresses a crash related to objects with custom visibility that are deleted from the grid without being properly unregistered from the map. The main change ensures that such objects are removed from the map's custom visibility set before deletion, preventing use-after-free crashes during player visibility updates.

**Bug fix for custom visibility objects:**

* Updated `ObjectGridUnloader::Visit` in `ObjectGridLoader.cpp` to explicitly remove objects with custom visibility from the map's custom visibility set before deletion, preventing crashes on subsequent visibility scans.ObjectGridUnloader::Visit is the one path that destroys a grid's objects without going through Map::RemoveFromMap, so an object registered in the map's custom visibility sets was never taken back out of them. The freed pointer stayed in the set until the next visibility scan walked it, which read fields off a destroyed object inside Player::UpdateVisibilityForPlayer and took the worldserver down - typically on the first login after the grid went idle, with nothing in the logs to point at it.

Unregister the object before deleting it, using the same zone id it was registered with.

(cherry picked from commit 90e9116a75e652ea248106fb9d06068e1c9bd75a)